### PR TITLE
Fix $page override in _setPageLanguage method

### DIFF
--- a/class.php
+++ b/class.php
@@ -169,10 +169,17 @@ class StaticSiteGenerator
     $kirby = $this->_kirby;
     $site = $kirby->site();
 
-      $page->content = null;
-      foreach ($page->files() as $file) {
+    $page->content = null;
+    foreach ($page->files() as $file) {
         $file->content = null;
-      }
+    }
+
+    foreach ($pages as $content_page) {
+        $content_page->content = null;
+        foreach ($content_page->files() as $file) {
+            $file->content = null;
+        }
+    }
 
     $site->content = null;
     foreach ($site->files() as $file) {


### PR DESCRIPTION
## Description

$page got overridden in the foreach loop. It's now called $content_page. 
The change from the original plugin must stay in tact, so all subpages are regenerated for menus to translate properly.

## Motivation

Menus didn't translate after your change.

## Testing

Tested locally. 